### PR TITLE
Revert change in API of AeFontManager

### DIFF
--- a/src/Alexandrie-Canvas-Tests/AeCanvasTest.class.st
+++ b/src/Alexandrie-Canvas-Tests/AeCanvasTest.class.st
@@ -271,7 +271,7 @@ AeCanvasTest >> renderEmoji [
 	emojiFTFace := AeFTLibraryResource current emojiFTFace.
 	cairoScaledFont :=
 		aeCanvas
-			scaledFontForFace: emojiFTFace newCairoFontFace
+			scaledFontForFace: emojiFTFace
 			size: fontHeight.
 
 	cairoGlyphsArray := cairoScaledFont glyphArrayForString: (Unicode value: 16r1F468) asString.
@@ -426,7 +426,10 @@ AeCanvasTest >> renderLigatureTextWithHarfbuzz [
 
 	"We do know this typeface defines a glyph for ff"
 	ffLigatureFTFace := AeFTLibraryResource current sourceSansProRegularFTFace.
-	cairoScaledFont := aeCanvas scaledFontForFace: ffLigatureFTFace newCairoFontFace size: fontSize.
+	cairoScaledFont :=
+		aeCanvas
+			scaledFontForFace: ffLigatureFTFace
+			size: fontSize.
 
 	"This is the key message send of this test"
 	cairoGlyphsArray := AeHbBuffer
@@ -457,7 +460,10 @@ AeCanvasTest >> renderLigatureTextWithoutHarfbuzz [
 
 	"We do know this typeface defines a glyph for ff"
 	ffLigatureFTFace := AeFTLibraryResource current sourceSansProRegularFTFace.
-	cairoScaledFont := aeCanvas scaledFontForFace: ffLigatureFTFace newCairoFontFace size: fontSize.
+	cairoScaledFont :=
+		aeCanvas
+			scaledFontForFace: ffLigatureFTFace
+			size: fontSize.
 
 	"We know that cairo ignores the ff ligature (that'd be provided by Harfbuzz)"
 	cairoGlyphsArray := cairoScaledFont glyphArrayForString: aString.
@@ -561,7 +567,7 @@ AeCanvasTest >> renderZWJEmojiWithHarfbuzz [
 	emojiFTFace := AeFTLibraryResource current emojiFTFace.
 	cairoScaledFont :=
 		aeCanvas
-			scaledFontForFace: emojiFTFace newCairoFontFace
+			scaledFontForFace: emojiFTFace
 			size: fontHeight.
 
 	"This is the key message send of this test"
@@ -596,7 +602,7 @@ AeCanvasTest >> renderZWJEmojiWithoutHarfbuzz [
 	emojiFTFace := AeFTLibraryResource current emojiFTFace.
 	cairoScaledFont :=
 		aeCanvas
-			scaledFontForFace: emojiFTFace newCairoFontFace
+			scaledFontForFace: emojiFTFace
 			size: fontHeight.
 
 	"We know that cairo ignores the ZWJ sequence (that'd be provided by Harfbuzz)"

--- a/src/Alexandrie-Canvas/AeCanvas.class.st
+++ b/src/Alexandrie-Canvas/AeCanvas.class.st
@@ -743,39 +743,17 @@ AeCanvas >> restoreContextOnlyIfClipAfterwards: aBlock [
 ]
 
 { #category : #'API - text' }
-AeCanvas >> scaledFontForFace: aFace size: fontSize [
-	"Answer a `AeCairoScaledFont` that corresponds to the provided face and point size."
+AeCanvas >> scaledFontForFace: aFace size: size [
+	"Answer a `AeCairoScaledFont` that corresponds to the provided face and size."
 
-	^ scaledFontCache
-		at: { aFace. fontSize }
+	^ scaledFontCache 
+		at: { aFace. size }
 		ifAbsentPut: [
 		 	| aFontMatrix |
-			aFontMatrix := AeCairoMatrix newScalingByX: fontSize y: fontSize.
+			aFontMatrix := AeCairoMatrix newScalingByX: size y: size.
 			
-			^ aFace
+			^ aFace newCairoFontFace
 				newScaledFontWithFontMatrix: aFontMatrix
-				userToDeviceMatrix: deviceScaleMatrix
-				options: fontOptions ]
-]
-
-{ #category : #'API - text' }
-AeCanvas >> scaledFontForFamily: familyName size: fontSize slant: slant weight: weight stretch: stretch [
-
-	^ scaledFontCache
-		at: { familyName. fontSize. slant. weight. stretch }
-		ifAbsentPut: [
-			| aCairoFontFace fontSizeMatrix |
-			aCairoFontFace := AeFontManager globalInstance
-				detectFamilyName: familyName
-				slant: slant
-				weight: weight
-				stretch: stretch
-				ifNone: [ AeFontManager globalInstance defaultFace ].
-
-			fontSizeMatrix := AeCairoMatrix newScalingByX: fontSize y: fontSize.
-			
-			aCairoFontFace
-				newScaledFontWithFontMatrix: fontSizeMatrix
 				userToDeviceMatrix: deviceScaleMatrix
 				options: fontOptions ]
 ]

--- a/src/Alexandrie-FontManager-Tests/AeFontManagerTest.class.st
+++ b/src/Alexandrie-FontManager-Tests/AeFontManagerTest.class.st
@@ -22,15 +22,14 @@ AeFontManagerTest >> testDetectFamilyNameSlantWeightStretchIfNone [
 		weight: AeFontWeight normal
 		stretch: AeFontStretch normal
 		ifNone: [ self fail ].
-	self assert: aCairoFontFace freetypeFace class equals: AeFTFace.
+	self assert: aCairoFontFace class equals: AeFTFace.
 
-	aCairoFontFace := aManager
+	aFace := aManager
 		detectFamilyName: 'INRIA SERIF' "<-- it ignores case"
 		slant: AeFontSlant italic
 		weight: AeFontWeight light
 		stretch: AeFontStretch normal
 		ifNone: [ self fail ].
-	aFace := aCairoFontFace freetypeFace.
 	self assert: aFace class equals: AeFTFace.
 	self assert: aFace familyName equals: 'Inria Serif'.
 	self assert: aFace isItalic.

--- a/src/Alexandrie-FontManager/AeFontManager.class.st
+++ b/src/Alexandrie-FontManager/AeFontManager.class.st
@@ -266,7 +266,7 @@ AeFontManager >> reset [
 			| fontFace |
 "			fontFace := anEntry newHbFont."
 			fontFace := anEntry newFaceWith: freetypeLibrary.
-			fontFace newCairoFontFace ];
+"			fontFace newCairoFontFace" ];
 		yourself
 ]
 

--- a/src/Alexandrie-Harfbuzz-Tests/AeHarfbuzzRenderExample.class.st
+++ b/src/Alexandrie-Harfbuzz-Tests/AeHarfbuzzRenderExample.class.st
@@ -150,7 +150,10 @@ AeHarfbuzzRenderExample >> newForm [
 	aeCanvas := AeCanvas extent: 1000 @ (fontHeight * 4).
 	aeCanvas clear: Color white.
 
-	cairoScaledFont := aeCanvas scaledFontForFace: freetypeFace size: fontHeight.
+	cairoScaledFont :=
+		aeCanvas
+			scaledFontForFace: freetypeFace
+			size: fontHeight.
 
 	"Margin"
 	aeCanvas pathTranslate: (fontHeight/2) @ 0.


### PR DESCRIPTION
Let's postpone it until the new Harfbuzz lib comes with pahro vm... it was an uneeded change now.