### PR TITLE
Read png from memory

### DIFF
--- a/src/Alexandrie-Base/AeEnumeration.class.st
+++ b/src/Alexandrie-Base/AeEnumeration.class.st
@@ -74,6 +74,12 @@ AeEnumeration class >> underlinedNamePrefix [
 	^ self subclassResponsibility
 ]
 
+{ #category : #converting }
+AeEnumeration >> asInteger [
+
+	^ value asInteger
+]
+
 { #category : #accessing }
 AeEnumeration >> camelCaseName [
 

--- a/src/Alexandrie-Cairo-Tests/AeCairoImageSurfaceTest.class.st
+++ b/src/Alexandrie-Cairo-Tests/AeCairoImageSurfaceTest.class.st
@@ -120,14 +120,6 @@ AeCairoImageSurfaceTest >> testConvertZeroWidthAsFormARGB32 [
 ]
 
 { #category : #tests }
-AeCairoImageSurfaceTest >> testErrorReadingPNG [
-
-	self
-		should: [ AeCairoImageSurface newFromPngFileAt: 'unexisting_png' asFileReference ]
-		raise: AeCairoStatusError
-]
-
-{ #category : #tests }
 AeCairoImageSurfaceTest >> testExtent [
 
 	surface := AeCairoImageSurface extent: 100 @ 50.
@@ -336,9 +328,10 @@ AeCairoImageSurfaceTest >> testPremultipliedAlphaConversionFromForm [
 ]
 
 { #category : #tests }
-AeCairoImageSurfaceTest >> testReadNonASCIIFilenamePNG [
+AeCairoImageSurfaceTest >> testReadPNGFromNonASCIIFilename [
 
-	surface := AeCairoImageSurface newFromPngFileAt: AeFilesystemResources testsDirectory / 'import' / 'utf8-logō.png'.
+	surface := AeCairoImageSurface newFromPngFileAt:
+		AeFilesystemResources testsDirectory / 'import' / 'utf8-logō.png'.
 
 	self assert: surface extent equals: 100 @ 34
 ]
@@ -363,6 +356,14 @@ AeCairoImageSurfaceTest >> testReadPNGFromStreamError [
 
 	self
 		should: [ AeCairoImageSurface newFromPngOn: pngBytes readStream ]
+		raise: AeCairoStatusError
+]
+
+{ #category : #tests }
+AeCairoImageSurfaceTest >> testReadPNGFromUnexistingFileError [
+
+	self
+		should: [ AeCairoImageSurface newFromPngFileAt: 'unexisting_png' asFileReference ]
 		raise: AeCairoStatusError
 ]
 
@@ -392,7 +393,7 @@ AeCairoImageSurfaceTest >> testWidth [
 ]
 
 { #category : #tests }
-AeCairoImageSurfaceTest >> testWriteNonASCIIFilenamePNG [
+AeCairoImageSurfaceTest >> testWritePNGOnNonASCIIFilename [
 
 	| aPNGFileReference |
 	surface := AeCairoImageSurface extent: 2 @ 3.

--- a/src/Alexandrie-Cairo-Tests/AeCairoImageSurfaceTest.class.st
+++ b/src/Alexandrie-Cairo-Tests/AeCairoImageSurfaceTest.class.st
@@ -344,6 +344,29 @@ AeCairoImageSurfaceTest >> testReadNonASCIIFilenamePNG [
 ]
 
 { #category : #tests }
+AeCairoImageSurfaceTest >> testReadPNGFromStream [
+
+	AeFilesystemResources removeIconPNG binaryReadStreamDo: [ :stream |
+		surface := AeCairoImageSurface newFromPngOn: stream ].
+
+	self assert: surface status isSuccess.
+	self assert: surface extent equals: 16 @ 16
+]
+
+{ #category : #tests }
+AeCairoImageSurfaceTest >> testReadPNGFromStreamError [
+
+	| pngBytes |
+	pngBytes := AeFilesystemResources removeIconPNG
+		binaryReadStreamDo: [ :stream | stream upToEnd ].
+	pngBytes := pngBytes allButLast: 10.
+
+	self
+		should: [ AeCairoImageSurface newFromPngOn: pngBytes readStream ]
+		raise: AeCairoStatusError
+]
+
+{ #category : #tests }
 AeCairoImageSurfaceTest >> testStrideForWidthFormat [
 
 	self

--- a/src/Alexandrie-Cairo/AeCairoImageSurface.class.st
+++ b/src/Alexandrie-Cairo/AeCairoImageSurface.class.st
@@ -97,8 +97,8 @@ AeCairoImageSurface class >> newFromPngFileAt: aFileReference [
 	| encodedPath newInstance |
 	encodedPath := aFileReference pathString nullTerminatedEncodeWith: #utf8.
 	newInstance := self unownedNewFromPngFileAt: encodedPath.
-	newInstance status ensureIsSuccess.
 	newInstance autoRelease.
+	newInstance status ensureIsSuccess.
 	^ newInstance
 ]
 

--- a/src/Alexandrie-Cairo/AeCairoImageSurface.class.st
+++ b/src/Alexandrie-Cairo/AeCairoImageSurface.class.st
@@ -103,6 +103,21 @@ AeCairoImageSurface class >> newFromPngFileAt: aFileReference [
 ]
 
 { #category : #'instance creation' }
+AeCairoImageSurface class >> newFromPngOn: aReadStream [
+	"Answer a new image surface with the contents of a PNG binary read stream. 
+	
+	Note: this can be slow since cairo will parse the stream by calling multiple times a `FFICallback` which is slow.
+	
+	Raise `AeCairoStatusError` on failure."
+
+	| newInstance |
+	newInstance := self unownedNewFromPngOn: aReadStream.
+	newInstance autoRelease.
+	newInstance status ensureIsSuccess.
+	^ newInstance
+]
+
+{ #category : #'instance creation' }
 AeCairoImageSurface class >> newWithFormat: aFormat width: aWidth height: aHeight [
 	"Answer a new image surface of the specified format and extent."
 
@@ -152,6 +167,19 @@ AeCairoImageSurface class >> unownedNewForData: aData format: aFormat width: aWi
 ]
 
 { #category : #'instance creation' }
+AeCairoImageSurface class >> unownedNewFromPng: closure callback: readCallback [
+	"Return a new instance initialized with the contents of the PNG data read incrementally via the readCallback function, or a nil surface if any error occurred. A nil surface can be checked for with `cairo_surface_status()`.
+
+	See: https://www.cairographics.org/manual/cairo-PNG-Support.html#cairo-image-surface-create-from-png-stream"
+
+	^ self ffiCall: #(
+		AeCairoImageSurface
+		cairo_image_surface_create_from_png_stream (
+			FFICallback readCallback,
+			void *closure) )
+]
+
+{ #category : #'instance creation' }
 AeCairoImageSurface class >> unownedNewFromPngFileAt: pathUTF8Encoded [
 	"Return a new instance initialized with the contents of the PNG file, or a nil surface if any error occurred. A nil surface can be checked for with `cairo_surface_status()`.
 
@@ -161,6 +189,26 @@ AeCairoImageSurface class >> unownedNewFromPngFileAt: pathUTF8Encoded [
 		AeCairoImageSurface
 		cairo_image_surface_create_from_png (
 			const char * pathUTF8Encoded ) )
+]
+
+{ #category : #'instance creation' }
+AeCairoImageSurface class >> unownedNewFromPngOn: aReadStream [
+	"Return a new instance initialized with the contents of the PNG data read stream."
+
+	| readCallback |
+
+	readCallback := 
+		FFICallback
+			signature: #(AeCairoStatus (void ** closure, char ** buffer, uint size))
+			block: [ :closure :buffer :size |
+				| bytes |
+				bytes := aReadStream next: size.
+				LibC memCopy: bytes to: buffer size: size.
+				bytes size = size
+					ifFalse: [ AeCairoStatus readError ]
+					ifTrue: [ AeCairoStatus success ] ].
+
+	^ self unownedNewFromPng: nil callback: readCallback
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
Add binding to Cairo function that reads a PNG from memory

This function:
https://www.cairographics.org/manual/cairo-PNG-Support.html#cairo-image-surface-create-from-png-stream

Sadly, it seems to be slow because it reads gradually the png calling a `FFICallback`... 15ms to read a 256x256 png:
```smalltalk
[
surface := pngFile binaryReadStreamDo: [:stream |
	AeCairoImageSurface newFromPngOn: stream ].
] timeToRun. 
```